### PR TITLE
Fix Bundler version compatibility for Jekyll build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _site/
 .sass-cache/
 .jekyll-metadata
 .DS_Store
+.bundle/
+vendor/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,4 +74,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.17.2
+   2.1.4


### PR DESCRIPTION
## Summary
- Update BUNDLED WITH in Gemfile.lock from 1.17.2 to 2.1.4 to fix `Could not find public_suffix-5.0.0` error
- Add `.bundle/` and `vendor/` to .gitignore to exclude local bundle files

## Problem
Jekyll build failed with:
```
Could not find 'bundler' (1.17.2) required by your Gemfile.lock
Could not find public_suffix-5.0.0 in any of the sources (Bundler::GemNotFound)
```

## Solution
Updated the Bundler version in Gemfile.lock to match the installed version (2.1.4).

## Test plan
- [x] `bundle install` succeeds
- [x] `bundle exec jekyll build` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)