### PR TITLE
Add setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
 # hyoshida123.github.io
 
-Personal website. 
+Personal website.
 
-Live websites at https://hyoshida123.github.io/ 
+Live websites at https://hyoshida123.github.io/
 
-__Build Locally__
-`jekyll build`
+## Setup
 
-__Run Locally__
-`jekyll serve`
+```bash
+# Install gems locally (first time only)
+bundle config set --local path 'vendor/bundle'
+bundle install
+```
+
+## Build Locally
+
+```bash
+bundle exec jekyll build
+```
+
+## Run Locally
+
+```bash
+bundle exec jekyll serve
+```


### PR DESCRIPTION
## Summary
- Add setup section with bundle configuration steps
- Update build/run commands to use `bundle exec`

## Changes
The README now documents the required steps:
1. `bundle config set --local path 'vendor/bundle'`
2. `bundle install`
3. `bundle exec jekyll build` or `bundle exec jekyll serve`

This prevents the `Could not find public_suffix` error when building for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)