### PR TITLE
Update site branding and profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,10 +13,9 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: ひでブログ
-email: hyoshida at berkeley.edu
+title: hyoshida.dev
 description: >- # this means to ignore newlines until "baseurl:"
-  ブログ
+  Data Engineer in Japan | データエンジニアリングについて書いています
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://hyoshida123.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 github_username:  hyoshida123

--- a/about.md
+++ b/about.md
@@ -4,4 +4,6 @@ title: About
 permalink: /about/
 ---
 
-I am an undergraduate student who studies Electrical Engineering and Computer Science at UC Berkeley. 
+Data Engineer at a startup in Japan.
+
+日本のスタートアップでデータエンジニアをしています。 


### PR DESCRIPTION
## Summary
- Site title: `ひでブログ` → `hyoshida.dev`
- Description: bilingual tagline for Data Engineer
- About page: updated to current role
- Removed email address

## Changes

**_config.yml**
```yaml
title: hyoshida.dev
description: Data Engineer in Japan | データエンジニアリングについて書いています
```

**about.md**
```
Data Engineer at a startup in Japan.
日本のスタートアップでデータエンジニアをしています。
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)